### PR TITLE
docs: Cartesi-risczero integration docs as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "docs/cartesi-co-processor-tutorial"]
 	path = docs/cartesi-co-processor-tutorial
 	url = https://github.com/Mugen-Builders/cartesi-co-processor-tutorial.git
+[submodule "docs/cartesi-risczero-tutorial"]
+	path = docs/cartesi-risczero-tutorial
+	url = https://github.com/Mugen-Builders/cartesi-risczero-tutorial.git

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -101,7 +101,25 @@ const sidebars: SidebarsConfig = {
         'cartesi-co-processor-tutorial/limitations',
         'cartesi-co-processor-tutorial/troubleshooting',
       ],
-    }
+    },
+    {
+      type: 'category',
+      label: 'Risc Zero Integration',
+      items: [
+        'cartesi-risczero-tutorial/introduction',
+        'cartesi-risczero-tutorial/architecture',
+        'cartesi-risczero-tutorial/installation',
+        {
+          type: 'category',
+          label: 'Development',
+          items: [
+            'cartesi-risczero-tutorial/development/generate-a-zk-proof',
+            'cartesi-risczero-tutorial/development/verify-a-zk-proof-in-cartesi-rollups',
+            'cartesi-risczero-tutorial/development/verify-a-zk-proof-with-coprocessor',
+          ],
+        },
+      ],
+    },
   ],
    
 };


### PR DESCRIPTION
### Summary
Added Cartesi-Risczero tutorial as a submodule under `docs/cartesi-risczero-tutorial`.

This pull request includes the addition of RiscZero integration documentation, focusing on architecture, proof generation, and proof verification in both Rollups and Processor perspectives. 

### Architecture Documentation:
* Added detailed explanations of the technical architecture, including system components and proof verification flow in 

### Proof Generation:
* Provided a comprehensive guide on creating a project to generate zero-knowledge proofs, including project structure, configuration files, and code examples

### Proof Verification:
* Added a step-by-step guide to creating Cartesi Rollups and Cartesi Coprocessor applications for verifying zero-knowledge proofs, including setting up dependencies, implementing the verifier, and sending proofs 

